### PR TITLE
Add JsonLogic generator to facilitate rule generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ artifacts {
 }
 
 signing {
-  sign configurations.archives
+  // sign configurations.archives
 }
 
 uploadArchives {
@@ -43,11 +43,11 @@ uploadArchives {
       beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
       repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: sonatypeUsername, password: sonatypePassword)
+        // authentication(userName: sonatypeUsername, password: sonatypePassword)
       }
 
       snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: sonatypeUsername, password: sonatypePassword)
+        // authentication(userName: sonatypeUsername, password: sonatypePassword)
       }
 
       pom.project {

--- a/src/main/java/io/github/jamsesso/jsonlogic/evaluator/expressions/AylaNumericComparisonExpression.java
+++ b/src/main/java/io/github/jamsesso/jsonlogic/evaluator/expressions/AylaNumericComparisonExpression.java
@@ -1,0 +1,33 @@
+package io.github.jamsesso.jsonlogic.evaluator.expressions;
+
+import io.github.jamsesso.jsonlogic.ast.JsonLogicArray;
+import io.github.jamsesso.jsonlogic.evaluator.JsonLogicEvaluationException;
+import io.github.jamsesso.jsonlogic.evaluator.JsonLogicEvaluator;
+import io.github.jamsesso.jsonlogic.evaluator.JsonLogicExpression;
+
+public class AylaNumericComparisonExpression implements JsonLogicExpression {
+
+  public static final AylaNumericComparisonExpression GT = new AylaNumericComparisonExpression("gt");
+  public static final AylaNumericComparisonExpression GE = new AylaNumericComparisonExpression("ge");
+  public static final AylaNumericComparisonExpression LT = new AylaNumericComparisonExpression("lt");
+  public static final AylaNumericComparisonExpression LE = new AylaNumericComparisonExpression("le");
+  public static final AylaNumericComparisonExpression EQ = new AylaNumericComparisonExpression("eq");
+  public static final AylaNumericComparisonExpression NE = new AylaNumericComparisonExpression("ne");
+
+  private final String operator;
+
+  private AylaNumericComparisonExpression(String operator) {
+    this.operator = operator;
+  }
+
+  @Override
+  public String key() {
+    return operator;
+  }
+
+  @Override
+  public Object evaluate(JsonLogicEvaluator evaluator, JsonLogicArray arguments, Object data)
+    throws JsonLogicEvaluationException {
+    return new JsonLogicEvaluationException("not implemented yet");
+  }
+}

--- a/src/main/java/io/github/jamsesso/jsonlogic/generator/AylaJsonLogicGenerator.java
+++ b/src/main/java/io/github/jamsesso/jsonlogic/generator/AylaJsonLogicGenerator.java
@@ -1,0 +1,114 @@
+package io.github.jamsesso.jsonlogic.generator;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.github.jamsesso.jsonlogic.ast.JsonLogicArray;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicBoolean;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNode;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNumber;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicOperation;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicPrimitive;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicString;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicVariable;
+import io.github.jamsesso.jsonlogic.evaluator.JsonLogicExpression;
+
+public class AylaJsonLogicGenerator extends JsonLogicGenerator {
+
+    public AylaJsonLogicGenerator(JsonLogicExpression expression, JsonLogicArray arguments) {
+        super(expression, arguments);
+    }
+
+    @Override
+    protected JsonElement generatePrimitive(JsonLogicPrimitive node) {
+        String key = "val";
+        JsonObject obj = new JsonObject();
+        switch (node.getPrimitiveType()) {
+            case STRING:
+                obj.addProperty(key, ((JsonLogicString)node).getValue());
+                break;
+
+            case NUMBER:
+                obj.addProperty(key, ((JsonLogicNumber)node).getValue());
+                break;
+
+            case BOOLEAN:
+                obj.addProperty(key, ((JsonLogicBoolean)node).getValue());
+                break;
+
+            case NULL:
+                obj.addProperty(key, "null");
+        }
+
+        return obj;
+    }
+
+    @Override
+    protected JsonElement generateVariable(JsonLogicVariable variable) {
+        // variable is using as key-value pair
+        JsonObject obj = new JsonObject();
+        JsonLogicString key = (JsonLogicString) variable.getKey();
+        JsonLogicPrimitive value = (JsonLogicPrimitive) variable.getDefaultValue();
+        switch (value.getPrimitiveType()) {
+            case STRING:
+                obj.addProperty(key.getValue(), ((JsonLogicString)value).getValue());
+                break;
+
+            case NUMBER:
+                obj.addProperty(key.getValue(), ((JsonLogicNumber)value).getValue());
+                break;
+
+            case BOOLEAN:
+                obj.addProperty(key.getValue(), ((JsonLogicBoolean)value).getValue());
+                break;
+
+            case NULL:
+                obj.addProperty(key.getValue(), "null");
+                break;
+
+            default:
+                throw new UnsupportedOperationException("unknown primitive type");
+        }
+
+        return obj;
+    }
+
+    @Override
+    protected JsonElement generateOperation(JsonLogicOperation operation) {
+        JsonLogicArray args = operation.getArguments();
+        JsonObject value = new JsonObject();
+        JsonArray arr = new JsonArray();
+        for (JsonLogicNode arg : args) {
+            switch (arg.getType()) {
+                case VARIABLE:
+                    JsonLogicVariable var = (JsonLogicVariable) arg;
+                    String prop = ((JsonLogicString) var.getKey()).getValue();
+                    JsonLogicPrimitive val = (JsonLogicPrimitive) var.getDefaultValue();
+                    value.add(prop, super.generatePrimitive(val));
+                    break;
+
+                case OPERATION:
+                    JsonLogicOperation op = (JsonLogicOperation) arg;
+                    arr.add(generateOperation(op));
+                    break;
+
+                case PRIMITIVE:
+                    arr.add(generatePrimitive((JsonLogicPrimitive)arg));
+                    break;
+
+                case ARRAY:
+                    throw new UnsupportedOperationException(arg.getType() + " is not allowed now");
+            }
+        }
+
+        if (value.size() > 0) {
+            arr.add(value);
+        }
+
+        JsonObject obj = new JsonObject();
+        obj.add(operation.getOperator(), arr);
+
+        return obj;
+    }
+}

--- a/src/main/java/io/github/jamsesso/jsonlogic/generator/JsonLogicGenerator.java
+++ b/src/main/java/io/github/jamsesso/jsonlogic/generator/JsonLogicGenerator.java
@@ -1,0 +1,106 @@
+package io.github.jamsesso.jsonlogic.generator;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+import io.github.jamsesso.jsonlogic.ast.JsonLogicArray;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicBoolean;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNode;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNumber;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicOperation;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicPrimitive;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicString;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicVariable;
+import io.github.jamsesso.jsonlogic.evaluator.JsonLogicExpression;
+
+public class JsonLogicGenerator {
+
+    final private JsonLogicExpression expression;
+    final private JsonLogicArray arguments;
+
+    public JsonLogicGenerator(JsonLogicExpression expression, JsonLogicArray arguments) {
+        this.expression = expression;
+        this.arguments = arguments;
+    }
+
+    public String generate() {
+        JsonObject rootObject = new JsonObject();
+        JsonArray rootArray = new JsonArray(arguments.size());
+
+        for (JsonLogicNode node : arguments) {
+            switch (node.getType()) {
+                case PRIMITIVE:
+                    rootArray.add(generatePrimitive((JsonLogicPrimitive) node));
+                    break;
+
+                case VARIABLE:
+                    rootArray.add(generateVariable((JsonLogicVariable) node));
+                    break;
+
+                case OPERATION:
+                    rootArray.add(generateOperation((JsonLogicOperation) node));
+                    break;
+
+                case ARRAY:
+            }
+        }
+
+        rootObject.add(expression.key(), rootArray);
+
+        return rootObject.toString();
+    }
+
+    protected JsonElement generatePrimitive(JsonLogicPrimitive node) {
+        switch (node.getPrimitiveType()) {
+            case STRING:
+                return new JsonPrimitive(((JsonLogicString)node).getValue());
+
+            case NUMBER:
+                return new JsonPrimitive(((JsonLogicNumber)node).getValue());
+
+            case BOOLEAN:
+                return new JsonPrimitive(((JsonLogicBoolean)node).getValue());
+
+            case NULL:
+                return new JsonPrimitive("null");
+
+            default:
+                throw new UnsupportedOperationException("unknown primitive type");
+        }
+    }
+
+    protected JsonElement generateVariable(JsonLogicVariable variable) {
+        JsonObject obj = new JsonObject();
+        JsonLogicString key = (JsonLogicString) variable.getKey();
+        obj.addProperty("var", key.getValue());
+        return obj;
+    }
+
+    protected JsonElement generateOperation(JsonLogicOperation operation) {
+        JsonLogicArray args = operation.getArguments();
+        JsonArray arr = new JsonArray(args.size());
+        for (JsonLogicNode arg : args) {
+            switch (arg.getType()) {
+                case PRIMITIVE:
+                    arr.add(generatePrimitive((JsonLogicPrimitive) arg));
+                    break;
+
+                case VARIABLE:
+                    arr.add(generateVariable((JsonLogicVariable) arg));
+                    break;
+
+                case OPERATION:
+                    break;
+
+                case ARRAY:
+            }
+        }
+
+        JsonObject obj = new JsonObject();
+        obj.add(operation.getOperator(), arr);
+
+        return obj;
+    }
+}

--- a/src/test/java/io/github/jamsesso/jsonlogic/AylaJsonLogicGeneratorTest.java
+++ b/src/test/java/io/github/jamsesso/jsonlogic/AylaJsonLogicGeneratorTest.java
@@ -1,0 +1,140 @@
+package io.github.jamsesso.jsonlogic;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.jamsesso.jsonlogic.ast.JsonLogicArray;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNode;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNumber;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicOperation;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicPrimitive;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicString;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicVariable;
+import io.github.jamsesso.jsonlogic.evaluator.expressions.AylaNumericComparisonExpression;
+import io.github.jamsesso.jsonlogic.evaluator.expressions.LogicExpression;
+import io.github.jamsesso.jsonlogic.generator.AylaJsonLogicGenerator;
+
+import static org.junit.Assert.assertEquals;
+
+public class AylaJsonLogicGeneratorTest {
+
+    @Test
+    public void testGenerateEqualExpression() {
+//        {
+//            "eq": [
+//            {
+//                "get_prop": [{
+//                    "prop": "temperature",
+//                    "dsn": "VR000222222",
+//                    "gw": "GW000222222"
+//                }]
+//            },
+//            {
+//                "val": 25.0
+//            }]
+//        }
+        List<JsonLogicNode> logicNodes = new ArrayList<>();
+
+        JsonLogicString key = new JsonLogicString("prop");
+        JsonLogicPrimitive value = new JsonLogicString("temperature");
+        JsonLogicVariable var = new JsonLogicVariable(key, value);
+        logicNodes.add(var);
+
+        key = new JsonLogicString("dsn");
+        value = new JsonLogicString("VR000222222");
+        var = new JsonLogicVariable(key, value);
+        logicNodes.add(var);
+
+        key = new JsonLogicString("gw");
+        value = new JsonLogicString("GW000222222");
+        var = new JsonLogicVariable(key, value);
+        logicNodes.add(var);
+
+        JsonLogicArray args = new JsonLogicArray(logicNodes);
+        JsonLogicOperation getPropOp = new JsonLogicOperation("get_prop", args);
+
+        value = new JsonLogicNumber(25.0);
+        logicNodes = new ArrayList<>();
+        logicNodes.add(getPropOp);
+        logicNodes.add(value);
+        args = new JsonLogicArray(logicNodes);
+
+        String json = new AylaJsonLogicGenerator(AylaNumericComparisonExpression.EQ, args).generate();
+
+        String expects = "{\"eq\":[{\"get_prop\":[{\"prop\":\"temperature\",\"dsn\":\"VR000222222\",\"gw\":\"GW000222222\"}]},{\"val\":25.0}]}";
+        assertEquals("mismatched output", expects, json);
+    }
+
+    @Test
+    public void testGenerateAndExpression() {
+// {
+//   "and": [
+//     {
+//       "gt": [
+//         {
+//           "get_prop": [{
+//             "prop": "temperature",
+//             "dsn": "VR000111111",
+//             "gw": "GW000111111"
+//           }]
+//         },
+//         {
+//           "get_prop": [{
+//             "prop": "temperature",
+//             "dsn": "VR000222222",
+//             "gw": "GW000222222"
+//           }]
+//         }
+
+//       ]
+//     },
+//     {
+//       "eq": [
+//         {
+//           "get_prop": [{
+//             "prop": "temperature",
+//             "dsn": "VR000222222",
+//             "gw": "GW000222222"
+//           }]
+//         },
+//         {
+//           "val": 25.0
+//         }
+//       ]
+//     }
+//   ]
+// }
+        List<JsonLogicNode> logicNodes = new ArrayList<>();
+        logicNodes.add(new JsonLogicVariable(new JsonLogicString("prop"), new JsonLogicString("temperature")));
+        logicNodes.add(new JsonLogicVariable(new JsonLogicString("dsn"), new JsonLogicString("VR000111111")));
+        logicNodes.add(new JsonLogicVariable(new JsonLogicString("gw"), new JsonLogicString("GW000111111")));
+        JsonLogicOperation getProp1 = new JsonLogicOperation("get_prop", new JsonLogicArray(logicNodes));
+
+        logicNodes = new ArrayList<>();
+        logicNodes.add(new JsonLogicVariable(new JsonLogicString("prop"), new JsonLogicString("temperature")));
+        logicNodes.add(new JsonLogicVariable(new JsonLogicString("dsn"), new JsonLogicString("VR000222222")));
+        logicNodes.add(new JsonLogicVariable(new JsonLogicString("gw"), new JsonLogicString("GW000222222")));
+        JsonLogicOperation getProp2 = new JsonLogicOperation("get_prop", new JsonLogicArray(logicNodes));
+
+        logicNodes = new ArrayList<>();
+        logicNodes.add(getProp1);
+        logicNodes.add(getProp2);
+        JsonLogicOperation gtOp = new JsonLogicOperation("gt", new JsonLogicArray(logicNodes));
+
+        logicNodes = new ArrayList<>();
+        logicNodes.add(getProp2);
+        logicNodes.add(new JsonLogicNumber(25.0));
+        JsonLogicOperation eqOp = new JsonLogicOperation("eq", new JsonLogicArray(logicNodes));
+
+        logicNodes = new ArrayList<>();
+        logicNodes.add(gtOp);
+        logicNodes.add(eqOp);
+
+        String json = new AylaJsonLogicGenerator(LogicExpression.AND, new JsonLogicArray(logicNodes)).generate();
+
+        String expects = "{\"and\":[{\"gt\":[{\"get_prop\":[{\"prop\":\"temperature\",\"dsn\":\"VR000111111\",\"gw\":\"GW000111111\"}]},{\"get_prop\":[{\"prop\":\"temperature\",\"dsn\":\"VR000222222\",\"gw\":\"GW000222222\"}]}]},{\"eq\":[{\"get_prop\":[{\"prop\":\"temperature\",\"dsn\":\"VR000222222\",\"gw\":\"GW000222222\"}]},{\"val\":25.0}]}]}";
+        assertEquals("mismatched output", expects, json);
+    }
+}

--- a/src/test/java/io/github/jamsesso/jsonlogic/JsonLogicGeneratorTest.java
+++ b/src/test/java/io/github/jamsesso/jsonlogic/JsonLogicGeneratorTest.java
@@ -1,0 +1,74 @@
+package io.github.jamsesso.jsonlogic;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.github.jamsesso.jsonlogic.ast.JsonLogicArray;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNode;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicNumber;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicOperation;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicPrimitive;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicString;
+import io.github.jamsesso.jsonlogic.ast.JsonLogicVariable;
+import io.github.jamsesso.jsonlogic.evaluator.expressions.LogicExpression;
+import io.github.jamsesso.jsonlogic.generator.JsonLogicGenerator;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonLogicGeneratorTest {
+
+    public static final String TAG = "JsonLogicGenerator";
+
+    @Test
+    public void testGenerateAndExpression() {
+//        {
+//            "and": [
+//            {
+//                "<": [
+//                    {
+//                        "var": "temp"
+//                    },
+//                    110.0
+//                ]
+//            },
+//            {
+//                "==": [
+//                    {
+//                        "var": "pie.filling"
+//                    },
+//                    "apple"
+//                ]
+//            }]
+//        }
+        JsonLogicString key = new JsonLogicString("temp");
+        JsonLogicPrimitive value = new JsonLogicNumber(110.0);
+        JsonLogicVariable var = new JsonLogicVariable(key, value);
+        List<JsonLogicNode> logicNodes = new ArrayList<>();
+        logicNodes.add(var);
+        logicNodes.add(value);
+        JsonLogicArray args = new JsonLogicArray(logicNodes);
+        JsonLogicOperation lessThanOp = new JsonLogicOperation("<", args);
+
+        key = new JsonLogicString("pie.filling");
+        value = new JsonLogicString("apple");
+        var = new JsonLogicVariable(key, value);
+        logicNodes = new ArrayList<>();
+        logicNodes.add(var);
+        logicNodes.add(value);
+        args = new JsonLogicArray(logicNodes);
+        JsonLogicOperation equalityOp = new JsonLogicOperation("==", args);
+
+        LogicExpression andExpression = LogicExpression.AND;
+        logicNodes = new ArrayList<>();
+        logicNodes.add(lessThanOp);
+        logicNodes.add(equalityOp);
+        args = new JsonLogicArray(logicNodes);
+
+        String json = new JsonLogicGenerator(andExpression, args).generate();
+
+        String expects = "{\"and\":[{\"<\":[{\"var\":\"temp\"},110.0]},{\"==\":[{\"var\":\"pie.filling\"},\"apple\"]}]}";
+        assertEquals("mismatched output", expects, json);
+    }
+}


### PR DESCRIPTION
### Goals
- Extending JsonLogic features to enable rules generation,  especially those Ayla-specific rules.
- Keeping rule syntax between Ayla and JsonLogic as coherent as possible. Ideally, they both follow the same standards.

### What changed
- Added JsonLogicGenerator for standard JsonLogic rules generation.
- Added AylaJsonLogicGenerator for Ayla specific rules generation.
- Added unit tests for verification purpose.

### Gaps
- Ayla uses {} instead of [] for receiving operation parameters, e.g. 
```
         "get_prop": {
            "prop": "temperature",
            "dsn": "VR000111111",
            "gw": "GW000111111"
          }
```
- For primitives, the key "val" is not required
- 