### PR TITLE
Fix bug in missing_some

### DIFF
--- a/src/main/java/io/github/jamsesso/jsonlogic/evaluator/expressions/MissingExpression.java
+++ b/src/main/java/io/github/jamsesso/jsonlogic/evaluator/expressions/MissingExpression.java
@@ -23,13 +23,19 @@ public class MissingExpression implements PreEvaluatedArgumentsExpression {
 
   @Override
   public Object evaluate(List arguments, Object data) throws JsonLogicEvaluationException {
-    if (!MapLike.isEligible(data)) {
-      return arguments;
-    }
-
     if (isSome && (!ArrayLike.isEligible(arguments.get(1)) || !(arguments.get(0) instanceof Double))) {
       throw new JsonLogicEvaluationException("missing_some expects first argument to be an integer and the second " +
-                                             "argument to be an array");
+              "argument to be an array");
+    }
+
+    if (!MapLike.isEligible(data)) {
+      if (isSome) {
+        if (((Double) arguments.get(0)).intValue() <= 0) {
+          return Collections.EMPTY_LIST;
+        }
+        return arguments.get(1);
+      }
+      return arguments;
     }
 
     Map map = new MapLike(data);

--- a/src/test/java/io/github/jamsesso/jsonlogic/MissingExpressionTests.java
+++ b/src/test/java/io/github/jamsesso/jsonlogic/MissingExpressionTests.java
@@ -64,4 +64,21 @@ public class MissingExpressionTests {
 
     assertEquals("We require first name, last name, and one phone number.", result);
   }
+
+  @Test
+  public void testMissingSomeWithNullData() throws JsonLogicException {
+    Object result = jsonLogic.apply("{\"missing_some\": [2, [\"a\", \"b\", \"c\"]]}", null);
+
+    assertEquals(3, ((List) result).size());
+    assertEquals("a", ((List) result).get(0));
+    assertEquals("b", ((List) result).get(1));
+    assertEquals("c", ((List) result).get(2));
+  }
+
+  @Test
+  public void testMissingSomeWithZeroThreshold() throws JsonLogicException {
+    Object result = jsonLogic.apply("{\"missing_some\": [0, [\"a\", \"b\", \"c\"]]}", null);
+
+    assertEquals(0, ((List) result).size());
+  }
 }


### PR DESCRIPTION
When `missing_some` is applied to a `null` data object, it would return
all its arguments, including the threshold. According to the spec, it
should return an array of the missing keys.

Also, if the threshold is 0, it should always return an empty list,
even when data is `null`.