### PR TITLE
Avoid NullPointerException if first argument to "in" is null

### DIFF
--- a/src/main/java/io/github/jamsesso/jsonlogic/evaluator/expressions/InExpression.java
+++ b/src/main/java/io/github/jamsesso/jsonlogic/evaluator/expressions/InExpression.java
@@ -25,6 +25,9 @@ public class InExpression implements PreEvaluatedArgumentsExpression {
 
     // Handle string in (substring)
     if (arguments.get(1) instanceof String) {
+      if (arguments.get(0) == null) {
+        return false;
+      }
       return ((String) arguments.get(1)).contains(arguments.get(0).toString());
     }
 

--- a/src/test/java/io/github/jamsesso/jsonlogic/InExpressionTests.java
+++ b/src/test/java/io/github/jamsesso/jsonlogic/InExpressionTests.java
@@ -22,17 +22,20 @@ public class InExpressionTests {
   @Test
   public void testStringNotIn() throws JsonLogicException {
     assertEquals(false, jsonLogic.apply("{\"in\": [\"race\", \"clouds\"]}", null));
+    assertEquals(false, jsonLogic.apply("{\"in\": [null, \"clouds\"]}", null));
   }
 
   @Test
   public void testArrayIn() throws JsonLogicException {
     assertEquals(true, jsonLogic.apply("{\"in\": [1, [1, 2, 3]]}", null));
     assertEquals(true, jsonLogic.apply("{\"in\": [4.56, [1, 2, 3, 4.56]]}", null));
+    assertEquals(true, jsonLogic.apply("{\"in\": [null, [1, 2, 3, null]]}", null));
   }
 
   @Test
   public void testArrayNotIn() throws JsonLogicException {
     assertEquals(false, jsonLogic.apply("{\"in\": [5, [1, 2, 3]]}", null));
+    assertEquals(false, jsonLogic.apply("{\"in\": [null, [1, 2, 3]]}", null));
   }
 
   @Test
@@ -45,6 +48,7 @@ public class InExpressionTests {
   public void testNotInVariableInt() throws JsonLogicException {
     Map data = Collections.singletonMap("list", Arrays.asList(1, 2, 3));
     assertEquals(false, jsonLogic.apply("{\"in\": [4, {\"var\": \"list\"}]}", data));
+    assertEquals(false, jsonLogic.apply("{\"in\": [4, {\"var\": \"list\"}]}", null));
   }
 
   @Test
@@ -55,6 +59,7 @@ public class InExpressionTests {
     }).collect(Collectors.toMap(o -> o[0], o -> o[1]));
 
     assertEquals(true, jsonLogic.apply("{\"in\": [{\"var\": \"value\"}, {\"var\": \"list\"}]}", data));
+    assertEquals(false, jsonLogic.apply("{\"in\": [{\"var\": \"value\"}, {\"var\": \"list\"}]}", null));
   }
 
   @Test


### PR DESCRIPTION
`in` of strings would fail with `NullPointerException` if the first
argument was `null`.
Also add some tests with `null` in various places.