### PR TITLE
Fix: Distinguish missing vs null in `var` resolution (use default only when missing)

### DIFF
--- a/src/main/java/io/github/jamsesso/jsonlogic/evaluator/JsonLogicEvaluator.java
+++ b/src/main/java/io/github/jamsesso/jsonlogic/evaluator/JsonLogicEvaluator.java
@@ -6,6 +6,10 @@ import io.github.jamsesso.jsonlogic.utils.ArrayLike;
 import java.util.*;
 
 public class JsonLogicEvaluator {
+
+  /** Sentinel object to represent a missing value (for internal use only). */
+  private static final Object MISSING = new Object();
+
   private final Map<String, JsonLogicExpression> expressions;
 
   public JsonLogicEvaluator(Collection<JsonLogicExpression> expressions) {
@@ -82,8 +86,10 @@ public class JsonLogicEvaluator {
       for (String partial : keys) {
         result = evaluatePartialVariable(partial, result, jsonPath + "[0]");
 
-        if (result == null) {
+        if (result == MISSING) {
           return defaultValue;
+        } else if (result == null) {
+          return null;
         }
       }
 
@@ -106,14 +112,19 @@ public class JsonLogicEvaluator {
       }
 
       if (index < 0 || index >= list.size()) {
-        return null;
+        return MISSING;
       }
 
       return transform(list.get(index));
     }
 
     if (data instanceof Map) {
-      return transform(((Map) data).get(key));
+      Map<?, ?> map = (Map<?, ?>) data;
+      if (map.containsKey(key)) {
+        return transform(map.get(key));
+      } else {
+        return MISSING;
+      }
     }
 
     return null;

--- a/src/test/java/io/github/jamsesso/jsonlogic/VariableTests.java
+++ b/src/test/java/io/github/jamsesso/jsonlogic/VariableTests.java
@@ -3,12 +3,15 @@ package io.github.jamsesso.jsonlogic;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class VariableTests {
   private static final JsonLogic jsonLogic = new JsonLogic();
@@ -98,5 +101,116 @@ public class VariableTests {
     assertEquals(1337.0, jsonLogic.apply("{\"var\": \"users.0.followers\"}", data));
     assertEquals("Jane", jsonLogic.apply("{\"var\": \"users.1.name\"}", data));
     assertEquals(2048.0, jsonLogic.apply("{\"var\": \"users.1.followers\"}", data));
+  }
+
+  @Test
+  public void missingNestedMapKey_returnsDefault() throws JsonLogicException {
+    // data.a.b is missing -> should use default
+    String rule = "{\"var\": [\"a.b.c\", \"fallback\"]}";
+    Map<String, Object> data = map("a", map("b", new HashMap<>()));
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertEquals("fallback", result);
+  }
+
+  @Test
+  public void presentNullLeaf_returnsNull_notDefault() throws JsonLogicException {
+    // data.user.age present with value null -> should return null (no default)
+    String rule = "{\"var\": [\"user.age\", 42]}";
+    Map<String, Object> user = new HashMap<>();
+    user.put("age", null);
+    Map<String, Object> data = map("user", user);
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void intermediateNull_returnsNull_notDefault() throws JsonLogicException {
+    // data.a.b is null before finishing path -> should return null (no default)
+    String rule = "{\"var\": [\"a.b.c\", \"fallback\"]}";
+    Map<String, Object> data = map("a", map("b", null));
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void nonTraversableIntermediate_returnsNull_notDefault() throws JsonLogicException {
+    // data.a is a number; trying to access a.b -> should return null (no default)
+    String rule = "{\"var\": [\"a.b\", \"fallback\"]}";
+    Map<String, Object> data = map("a", 5);
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void arrayIndexWithinBounds_returnsElement_asDoubleForNumbers() throws JsonLogicException {
+    // items.1 exists -> should return 20 (as a double per evaluator.transform)
+    String rule = "{\"var\": [\"items.1\", 999]}";
+    Map<String, Object> data = map("items", Arrays.asList(10, 20));
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertTrue(result instanceof Number);
+    assertEquals(20.0, ((Number) result).doubleValue(), 0.0);
+  }
+
+  @Test
+  public void arrayIndexOutOfBounds_returnsDefault() throws JsonLogicException {
+    // items.2 missing -> use default
+    String rule = "{\"var\": [\"items.2\", \"missing\"]}";
+    Map<String, Object> data = map("items", Arrays.asList(10, 20));
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertEquals("missing", result);
+  }
+
+  @Test
+  public void arrayElementPresentButNull_returnsNull_notDefault() throws JsonLogicException {
+    // items.0 exists and is null -> should return null (no default)
+    String rule = "{\"var\": [\"items.0\", \"missing\"]}";
+    Map<String, Object> data = map("items", Collections.singletonList(null));
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void topLevelNumericIndex_overList_works() throws JsonLogicException {
+    // {"var": [1, "missing"]} over a top-level list -> "banana"
+    String rule = "{\"var\": [1, \"missing\"]}";
+    List<String> data = Arrays.asList("apple", "banana", "carrot");
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertEquals("banana", result);
+  }
+
+  @Test
+  public void emptyVarKey_returnsWholeDataObject() throws JsonLogicException {
+    // {"var": ""} should return the entire data object (same instance)
+    String rule = "{\"var\": \"\"}";
+    Map<String, Object> data = map("x", 1);
+
+    Object result = jsonLogic.apply(rule, data);
+
+    assertSame("Should return the same data instance", data, result);
+  }
+
+  /** Helper to make small maps concisely. */
+  private static Map<String, Object> map(Object... kv) {
+    Map<String, Object> m = new HashMap<>();
+    for (int i = 0; i < kv.length; i += 2) {
+      m.put((String) kv[i], kv[i + 1]);
+    }
+    return m;
   }
 }


### PR DESCRIPTION
Supersedes #58; this PR contains only the fix.

This fixes `var` resolution so a default is applied only when the path is *missing*, not when the value is explicitly `null`.

## Why
Per the JsonLogic docs, the second `var` argument is a default “for values that might be missing.” Treating `null` as missing deviates from that intent and leads to surprising results.

## What changed
- Introduced an internal `MISSING` sentinel to track “not found” during path traversal.  
- Map access now uses `containsKey` to differentiate an absent key from a present key with `null`.  
- Array access returns `MISSING` for out-of-bounds indices.  
- `evaluate(JsonLogicVariable, …)` applies the default only when the traversal yields `MISSING`; explicit `null` is returned as `null`.

## Examples
- `{"var": ["user.age", 42]}` with `{"user":{"age": null}}` → **null** (no default)  
- `{"var": ["items.2", "missing"]}` with `{"items":[10,20]}` → **"missing"**  
- `{"var": ""}` returns the entire data object (same instance)

## Tests
Added coverage to `VariableTests`:
- Missing nested key falls back to default.  
- Present leaf `null` returns `null` (no default).  
- Intermediate `null` or non-traversable types return `null`.  
- Array index in-bounds returns the element; out-of-bounds uses default.  
- Top-level numeric index over lists works.  
- Empty `var` key returns the original data object.

## Compatibility
Behavior change for callers who relied on “default-for-null.” This aligns with the JsonLogic spec and other interpreters.