### PR TITLE
Fix error and optimize ArrayLike.java

### DIFF
--- a/src/main/java/io/github/jamsesso/jsonlogic/utils/ArrayLike.java
+++ b/src/main/java/io/github/jamsesso/jsonlogic/utils/ArrayLike.java
@@ -165,6 +165,9 @@ public class ArrayLike implements List<Object> {
     if (this == other) {
       return true;
     }
+    if (other instanceof Collection &&  ((Collection)other).size() != delegate.size()) {
+      return false;
+    }
 
     if (other instanceof Iterable) {
       int i = 0;
@@ -180,8 +183,8 @@ public class ArrayLike implements List<Object> {
         i++;
       }
 
-      if (i != delegate.size()) {
-        return false;
+      if (i == delegate.size()) {
+        return true;
       }
 
       return false;


### PR DESCRIPTION
1) In the equals there was an false if statement causing equals to fail on equal collections 2) If other is Collection we can check size before starting iteration.